### PR TITLE
Fix Json class PHPDoc

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -4,7 +4,7 @@ namespace Brryfrmnn\Transformers;
 
 
 /**
- *  Class Json is transformers from raw data to json view
+ *  Class Json transforms raw data into a JSON response.
  */
 class Json
 {


### PR DESCRIPTION
## Summary
- clarify the PHPDoc for the Json class

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685513016090832f8fda45339480a7ea