### PR TITLE
Fix paginator currentPage method

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -29,7 +29,7 @@ class Json
             $pagination = $data->toArray();
             $result['meta']['total'] = $data->total();
             $result['meta']['per_page'] = $data->perPage();
-            $result['meta']['current_page'] = $data->currentpage();
+            $result['meta']['current_page'] = $data->currentPage();
             $result['meta']['last_page'] = $data->lastPage();
             $result['meta']['from'] = $pagination['from'];;
             $result['meta']['to'] = $pagination['to'];


### PR DESCRIPTION
## Summary
- follow Laravel paginator API with `currentPage()`

## Testing
- `php -l src/Json.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685512df809c832fac310ddcfb9cb4d9